### PR TITLE
Added attribute "target='_blank'" to script.js

### DIFF
--- a/script.js
+++ b/script.js
@@ -104,7 +104,7 @@ class finder
                 </tr
 
                 <tr>
-                    <td style="color:chocolate";><b>Github Url :</b> <a href="${data.html_url}">${data.html_url}</a></td>
+                    <td style="color:chocolate";><b>Github Url :</b> <a href="${data.html_url}" target="_blank">${data.html_url}</a></td>
                 </tr>
                 </div>
             `;

--- a/script.js
+++ b/script.js
@@ -104,7 +104,7 @@ class finder
                 </tr
 
                 <tr>
-                    <td style="color:chocolate";><b>Github Url :</b> <a href="${data.html_url}" target="_blank">${data.html_url}</a></td>
+                    <td style="color:chocolate";><b>Github Url :</b> <a href="${data.html_url}" target="_blank">${data.html_url}</a></td> <!--added target="_blank"-->
                 </tr>
                 </div>
             `;


### PR DESCRIPTION
# Description
Added attribute "target='_blank'" to open Github profile links in a new tab in script.js.

Fixes #34

# Type of Change:
**Delete irrelevant options.**

- Code
- Quality Assurance
- User Interface
- Documentation


# Screenshots
Screenshots of the proposed changes compared with the current version of the project
**Before**
![Screenshot     ####(120)](https://user-images.githubusercontent.com/58758331/90521653-6e446780-e188-11ea-9287-d4878f29ced2.png)
**After**
![Screenshot (119)](https://user-images.githubusercontent.com/58758331/90521722-80260a80-e188-11ea-9fcf-40ed0c8c9dcd.png)


# Checklist:

- [o] My code follows the style guidelines(Clean Code) of this project
- [o] I have performed a self-review of my own code
- [o] I have commented on my code, particularly in hard-to-understand areas
- [o] I have added tests/screenshots(If any) that prove my fix is effective or that my feature works.