### PR TITLE
Clickable direct links for user profile result at Analyze Profile as well as GitHub Profile Comparison Tool

### DIFF
--- a/js/analyseProfile.js
+++ b/js/analyseProfile.js
@@ -75,39 +75,44 @@ addUserToList(data,repos,c)
             <div class="user-image">
                 <img src="${data.avatar_url}" alt="" id = "profile-pic">
             </div>
+            
             <tr>
-                <td style="color:chocolate";><b>Name :</b> ${data.name}</td>
+                <td style="color:chocolate;"><b>Name :</b> ${data.name}</td>
+            </tr>
+
+            <tr><td style="color:chocolate;"><b>About:</b> ${data.bio} </td></tr>
+
+            ${ (data.blog)?`<tr><td><a style="color:chocolate" href="${data.blog}" href="_blank"><b>Custom Site:</b> ${data.blog} </td></tr>`:"" }
+
+            <tr>
+                <td style="color:chocolate;"><b>Location :</b> ${data.location} </td>
             </tr>
 
             <tr>
-                <td style="color:chocolate";><b>Location :</b> ${data.location} </td>
+                <td style="color:chocolate;"><a href="${data.html_url}?tab=followers" target="_blank"><b>Followers :</b> ${data.followers}</a></td>
             </tr>
 
             <tr>
-                <td style="color:chocolate";><b>Followers :</b> ${data.followers}</td>
+                <td style="color:chocolate;"><a href="${data.html_url}?tab=following" target="_blank"><b>Following :</b> ${data.following}</a></td>
             </tr>
 
             <tr>
-                <td style="color:chocolate";><b>Following :</b> ${data.following}</td>
+                <td style="color:chocolate;"><a href="${data.html_url}?tab=repositories" target="_blank"><b>Total Repositories :</b> ${data.public_repos}</a></td>
             </tr>
 
             <tr>
-                <td style="color:chocolate";><b>Total Repositories :</b> ${data.public_repos}</td>
+                <td style="color:chocolate;"><a href="${data.html_url}?tab=stars" target="_blank"><b>Total Stars :</b> ${stars}</a></td>
             </tr>
 
             <tr>
-                <td style="color:chocolate";><b>Total Stars :</b> ${stars}</td>
-            </tr>
-
-            <tr>
-                <td style="color:chocolate";><b>GitHub Grade :</b> ${Grade}</td>
+                <td style="color:chocolate;"><b>GitHub Grade :</b> ${Grade}</td>
             </tr
 
             <tr>
-                <td style="color:chocolate";><b>Github Url :</b> <a href="${data.html_url}">${data.html_url}</a></td>
+                <td style="color:chocolate;"><b>Github Url :</b> <a href="${data.html_url}">${data.html_url}</a></td>
             </tr>
             </div>
-        `;
+`;
 
         list.appendChild(table);
     }

--- a/js/script.js
+++ b/js/script.js
@@ -76,35 +76,41 @@ class finder
                     <img src="${data.avatar_url}" alt="" id = "profile-pic">
                 </div>
                 <tr>
-                    <td style="color:chocolate";><b>Name :</b> ${data.name}</td>
+                    <td style="color:chocolate;"><b>Name :</b> ${data.name}</td>
                 </tr>
 
                 <tr>
-                    <td style="color:chocolate";><b>Location :</b> ${data.location} </td>
+                    <td style="color:chocolate;"><b>About:</b> ${data.bio} </td>
+                </tr>
+
+                ${ (data.blog)?`<tr><td><a style="color:chocolate" href="${data.blog}" href="_blank"><b>Custom Site:</b> ${data.blog} </td></tr>`:"" }
+
+                <tr>
+                    <td style="color:chocolate;"><b>Location :</b> ${data.location} </td>
                 </tr>
 
                 <tr>
-                    <td style="color:chocolate";><b>Followers :</b> ${data.followers}</td>
+                    <td style="color:chocolate;"><a href="${data.html_url}?tab=followers"><b>Followers :</b> ${data.followers}</a></td>
                 </tr>
 
                 <tr>
-                    <td style="color:chocolate";><b>Following :</b> ${data.following}</td>
+                    <td style="color:chocolate;"><a href="${data.html_url}?tab=following"><b>Following :</b> ${data.following}</a></td>
                 </tr>
 
                 <tr>
-                    <td style="color:chocolate";><b>Total Repositories :</b> ${data.public_repos}</td>
+                    <td style="color:chocolate;"><a href="${data.html_url}?tab=repositories"><b>Total Repositories :</b> ${data.public_repos}</a></td>
                 </tr>
 
                 <tr>
-                    <td style="color:chocolate";><b>Total Stars :</b> ${stars}</td>
+                    <td style="color:chocolate;"><a href="${data.html_url}?tab=stars"><b>Total Stars :</b> ${stars}</a></td>
                 </tr>
 
                 <tr>
-                    <td style="color:chocolate";><b>GitHub Grade :</b> ${Grade}</td>
+                    <td style="color:chocolate;"><b>GitHub Grade :</b> ${Grade}</td>
                 </tr
 
                 <tr>
-                    <td style="color:chocolate";><b>Github Url :</b> <a href="${data.html_url}" target="_blank">${data.html_url}</a></td> <!--added target="_blank"-->
+                    <td style="color:chocolate;"><b>Github Url :</b> <a href="${data.html_url}" target="_blank">${data.html_url}</a></td> <!--added target="_blank"-->
                 </tr>
                 </div>
             `;


### PR DESCRIPTION
# Description
Include a summary of the change and relevant motivation/context. List any dependencies that are required for this change.
With this PR, the profile data gets direct links for their displayed data viz., Followers, Following, Total Repositories, Total Stars and Custom Site (GitHub Pages one, if exists).

Fixes #88 

# Type of Change:
- Code

# Screenshots
Screenshots of the proposed changes compared with the current version of the project

- Check out the direct links that are made available for followers, following, repositories and stars tabs.
![Capture-ClickableLinks-AnalyseProfile](https://user-images.githubusercontent.com/57865187/94684241-652ce580-0345-11eb-95d8-52ab915be0f1.PNG)

- Introducing optional column (named Custom Site)! Notice that it is visible only for those who have setup a custom site, hosted at their respective GitHub Page (In the image, it is available at 3rd row for the profile at right, whereas it isn't detected, and therefore the row is ommitted, for the profile at left).

![](https://user-images.githubusercontent.com/57865187/92103881-2ff0ae80-edfe-11ea-8b1f-820ac1bd6927.png)


# Checklist:

- [x] My code follows the style guidelines(Clean Code) of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests/screenshots(If any) that prove my fix is effective or that my feature works